### PR TITLE
Add support for Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 
 python:
     - '2.7'
+    - '3.4'
+    - '3.5'
 
 before_install:
     - pip install codecov

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open('README.rst', 'r') as fh:
     description = '\n'.join(fh.readlines())
 
 tests_require = [
-    'pytest>=2.6.0',
-    'pytest-cov>=1.7.0',
-    'pytest-django>=2.8.0',
+    'pytest>=2.8.3',
+    'pytest-cov>=2.2.0',
+    'pytest-django>=2.9.1',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     author_email="michaelvantellingen@gmail.com",
     install_requires=[
         'Django>=1.7',
+        'six>=1.1',
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require},
@@ -31,6 +32,12 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     zip_safe=False,
 )

--- a/src/django_healthchecks/checker.py
+++ b/src/django_healthchecks/checker.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.utils.importlib import import_module
 
+from six import iteritems
+
 try:
     from django.utils.module_loading import import_string
 except ImportError:
@@ -14,7 +16,7 @@ def create_report():
     report = {}
 
     checks = _get_registered_health_checks()
-    for service, func_string in checks.iteritems():
+    for service, func_string in iteritems(checks):
         check_func = import_string(func_string)
         report[service] = check_func() or False
     return report

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,7 +16,7 @@ def test_index_view(rf, settings):
     view = views.HealthCheckView()
     result = view.dispatch(request)
 
-    data = json.loads(result.content)
+    data = json.loads(result.content.decode(result.charset))
     assert data == {
         'database': True,
         'redis': False,
@@ -33,7 +33,7 @@ def test_service_view(rf, settings):
     result = view.dispatch(request, service='database')
 
     assert result.status_code == 200
-    assert result.content == 'true'
+    assert result.content == b'true'
 
 
 def test_service_view_err(rf, settings):
@@ -46,7 +46,7 @@ def test_service_view_err(rf, settings):
 
     result = view.dispatch(request, service='database')
     assert result.status_code == 200
-    assert result.content == 'false'
+    assert result.content == b'false'
 
 
 def test_service_view_404(rf):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py{27,34,35}
+
+[testenv]
+deps =
+    pytest>=2.6.0
+    pytest-cov>=1.7.0
+    pytest-django>=2.8.0
+commands =
+    py.test {posargs:tests}


### PR DESCRIPTION
Hi,

this pull request add support for Python 3.4 and 3.5 with the help of six. Tests are also slightly adjusted to run with Python2 and Python3.

The test suite can also be run in multiple environments with the help of Tox now.

Nice lib, btw. :+1: 