### PR TITLE
honor name parameter in _get_check_functions (for HealthCheckServiceV…

### DIFF
--- a/src/django_healthchecks/checker.py
+++ b/src/django_healthchecks/checker.py
@@ -55,6 +55,9 @@ def _get_check_functions(name=None, request=None):
         raise PermissionDenied()
 
     for service, func_string in checks.items():
+        if name and name != service:
+            continue
+
         check_func = import_string(func_string)
 
         spec = inspect.getargspec(check_func)


### PR DESCRIPTION
Was getting correct values with url like:
http://localhost:8000/healthchecks

...But not with the specific services:
http://localhost:8000/healthchecks/redis etc.

This seemed to fix it locally. Thanks for reviewing!