### PR TITLE
Make sure the cursor is properly closed after usage

### DIFF
--- a/src/django_healthchecks/contrib.py
+++ b/src/django_healthchecks/contrib.py
@@ -6,9 +6,9 @@ from django.db import connection
 
 def check_database():
     """Check if the application can perform a dummy sql query"""
-    cursor = connection.cursor()
-    cursor.execute('SELECT 1; -- Healthcheck')
-    row = cursor.fetchone()
+    with connection.cursor() as cursor:
+        cursor.execute('SELECT 1; -- Healthcheck')
+        row = cursor.fetchone()
     return row[0] == 1
 
 


### PR DESCRIPTION
This makes sure the connection is properly closed, so no memory leaks could happen. In MySQL it could even leave a connection open, as cursors are emulated on MySQL.

See https://stackoverflow.com/questions/24661754/necessity-of-explicit-cursor-close for more info.