### PR TITLE
Fix returning non-bool data from the HealthCheckServiceView

### DIFF
--- a/src/django_healthchecks/views.py
+++ b/src/django_healthchecks/views.py
@@ -59,10 +59,11 @@ class HealthCheckServiceView(NoCacheMixin, View):
         if result in (True, False):
             status_code = 200 if result else _get_err_status_code()
             return HttpResponse(str(result).lower(), status=status_code)
-
-        if not isinstance(result, six.text_type):
-            return JsonResponse(result)
-        return HttpResponse(result)
+        elif isinstance(result, six.string_types) or isinstance(result, bytes):
+            return HttpResponse(result)
+        else:
+            # Django requires safe=False for non-dict values.
+            return JsonResponse(result, safe=False)
 
 
 def _get_err_status_code():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,9 +2,18 @@ import json
 from collections import OrderedDict
 
 import pytest
+import requests_mock
 from django.http import Http404
 
 from django_healthchecks import views
+
+
+def check_int():
+    return 2
+
+
+def check_float():
+    return 1.5
 
 
 def test_index_view(rf, settings):
@@ -24,7 +33,7 @@ def test_index_view(rf, settings):
     }
 
 
-def test_service_view(rf, settings):
+def test_service_view_bool(rf, settings):
     settings.HEALTH_CHECKS = OrderedDict([
         ('redis', 'django_healthchecks.contrib.check_dummy_false'),
         ('database', 'django_healthchecks.contrib.check_dummy_true'),
@@ -36,6 +45,72 @@ def test_service_view(rf, settings):
 
     assert result.status_code == 200
     assert result.content == b'true'
+
+
+def test_service_view_bytes(rf, settings):
+    # This tests the serilization contraints
+    settings.HEALTH_CHECKS = OrderedDict([
+        ('ip', 'django_healthchecks.contrib.check_remote_addr'),
+    ])
+
+    request = rf.get('/')
+    view = views.HealthCheckServiceView()
+    result = view.dispatch(request, service='ip')
+
+    assert result.status_code == 200
+    assert result.content == b'127.0.0.1'
+
+
+def test_service_view_int(rf, settings):
+    # This tests the serilization contraints
+    settings.HEALTH_CHECKS = OrderedDict([
+        ('val', check_int),
+    ])
+
+    request = rf.get('/')
+    view = views.HealthCheckServiceView()
+    result = view.dispatch(request, service='val')
+
+    assert result.status_code == 200
+    assert result['Content-Type'] == 'application/json'
+    assert result.content == b'2'
+
+
+def test_service_view_float(rf, settings):
+    # This tests the serilization contraints
+    settings.HEALTH_CHECKS = OrderedDict([
+        ('val', check_float),
+    ])
+
+    request = rf.get('/')
+    view = views.HealthCheckServiceView()
+    result = view.dispatch(request, service='val')
+
+    assert result.status_code == 200
+    assert result['Content-Type'] == 'application/json'
+    assert result.content == b'1.5'
+
+
+def test_service_view_remote(rf, settings):
+    settings.HEALTH_CHECKS = {
+        'remote_service': 'https://test.com/api/healthchecks/',
+    }
+
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            'https://test.com/api/healthchecks/',
+            json={"cache_default": True})
+
+        request = rf.get('/')
+        view = views.HealthCheckServiceView()
+        result = view.dispatch(request, service='remote_service')
+
+    expected = {'cache_default': True}
+    data = json.loads(result.content.decode(result.charset))
+
+    assert result.status_code == 200
+    assert result['Content-Type'] == 'application/json'
+    assert data == expected
 
 
 def test_service_view_err(rf, settings):


### PR DESCRIPTION
The recent changes to access remote services changed the response type for the HealthCheckServiceView to JSON when it really should be returning raw data instead.

The `django.http.JsonResponse` does not accept non-dict data by default, raising an `TypeError` that `safe=True` should be passed to support this. This happens with the IP check in Python 2.

To discuss:
* Either the service end point should return the raw data (like it did before) and use `JsonResponse` for dict data only.
* Or it should use `JsonResponse(..., safe=False)` so all other types are encoded as JSON (this PR does that). The Django sources mention why the `safe=False` is there: https://docs.djangoproject.com/en/2.0/ref/request-response/#serializing-non-dictionary-objects
and https://security.stackexchange.com/q/159609/79435