### PR TITLE
Django 3.1 support, dropped support for django 1.1

### DIFF
--- a/src/django_healthchecks/urls.py
+++ b/src/django_healthchecks/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from django_healthchecks import views
 
 urlpatterns = [
-    url(r"^$", views.HealthCheckView.as_view(), name="index"),
-    url(r"^(?P<service>.*)$", views.HealthCheckServiceView.as_view(), name="service"),
+    path(r"", views.HealthCheckView.as_view(), name="index"),
+    path(r"<str:service>/", views.HealthCheckServiceView.as_view(), name="service"),
 ]

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 import django_healthchecks.urls
 
 urlpatterns = [
-    url("^admin/", admin.site.urls),
-    url("^healthchecks", include(django_healthchecks.urls)),
+    path("^admin/", admin.site.urls),
+    path("^healthchecks", include(django_healthchecks.urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{36,37,38}-django{111,22,30}
+envlist = py{36,37,38}-django{22,30,31}
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 deps =
-    django111: Django>=1.11,<1.12
     django20: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 extras = test
 
 [testenv:coverage-report]


### PR DESCRIPTION
Fixed RemovedInDjango40Warning about django.conf.urls.urls()

Dropped support for django 1.11

fixes f213/django#13